### PR TITLE
fix line disappearing problem

### DIFF
--- a/etc/zshrc.zsh
+++ b/etc/zshrc.zsh
@@ -145,6 +145,7 @@ FAST_HIGHLIGHT[chroma-git]="chroma/-ogit.ch"
 unsetopt correct_all
 unsetopt share_history
 setopt prompt_subst
+unsetopt prompt_cr prompt_sp
 
 setopt BANG_HIST                 # Treat the '!' character specially during expansion.
 setopt INC_APPEND_HISTORY        # Write to the history file immediately, not when the shell exits.


### PR DESCRIPTION
For example, if we print something without a newline,

```bash
echo 'print("hello", end="")' > test.py
python3 test.py
```

the output is empty. It seems the output is overwritten by the prompt.